### PR TITLE
support <script type="text/babel">

### DIFF
--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -42,7 +42,7 @@ endif
 
 syntax include @JS syntax/javascript.vim
 unlet b:current_syntax
-syntax region script keepend start=/<script>/ end="</script>" contains=@JS fold
+syntax region script keepend start=/<script\s*\(type="text\/babel"\)\?>/ end="</script>" contains=@JS fold
 
 if s:syntaxes.coffee
   syntax include @COFFEE syntax/coffee.vim


### PR DESCRIPTION
In my team, some people use WebStorm, they use  <script type="text/babel">, this tag make vim syntax no effect。
