### PR TITLE
Add indent and ftplugin files

### DIFF
--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -1,0 +1,10 @@
+" Vim filetype plugin
+" Language: Vue.js
+" Maintainer: Eduardo San Martin Morote
+" Author: Adriaan Zonnenberg
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/html.vim

--- a/indent/vue.vim
+++ b/indent/vue.vim
@@ -1,0 +1,39 @@
+" Vim indent file
+" Language: Vue.js
+" Maintainer: Eduardo San Martin Morote
+" Author: Adriaan Zonnenberg
+
+if exists("b:did_indent")
+  finish
+endif
+
+" Load indent files for required languages
+for language in ['stylus', 'pug', 'css', 'javascript', 'html']
+  unlet! b:did_indent
+  exe "runtime! indent/".language.".vim"
+  exe "let s:".language."indent = &indentexpr"
+endfor
+
+let b:did_indent = 1
+
+setlocal indentexpr=GetVueIndent()
+
+if exists("*GetVueIndent")
+  finish
+endif
+
+function! GetVueIndent()
+  if searchpair('<template lang="pug"', '', '</template>', 'bWr')
+    exe "let indent = ".s:pugindent
+  elseif searchpair('<style lang="stylus"', '', '</style>', 'bWr')
+    exe "let indent = ".s:stylusindent
+  elseif searchpair('<style', '', '</style>', 'bWr')
+    exe "let indent = ".s:cssindent
+  elseif searchpair('<script', '', '</script>', 'bWr')
+    exe "let indent = ".s:javascriptindent
+  else
+    exe "let indent = ".s:htmlindent
+  endif
+
+  return indent > -1 ? indent : s:htmlindent
+endfunction


### PR DESCRIPTION
I added indentation for css and javascript manually, instead of relying on Vim's indent/html.vim, because that seemed to work much better.  [othree's html5.vim](https://github.com/othree/html5.vim) also does this, so anthother solution might be to get rid of the css/js indentation rules and recommend the html5.vim plugin for better indentation.

Pug indentation didn't seem to work properly for me, even in standalone files.

I also included a `ftplugin/vue.vim` which sources `ftplugin/html.vim`.  This enables you to use matchit to jump between tag pairs.