### PR TITLE
Fix typo

### DIFF
--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -48,7 +48,7 @@ syntax include @JS syntax/javascript.vim
 if exists("b:current_syntax")
   unlet b:current_syntax
 endif
-syntax region javacript keepend start=/<script\( lang="babel"\)\?\( type="text\/babel"\)\?>/ end="</script>" contains=@JS fold
+syntax region javascript keepend start=/<script\( lang="babel"\)\?\( type="text\/babel"\)\?>/ end="</script>" contains=@JS fold
 
 if s:syntaxes.coffee
   syntax include @COFFEE syntax/coffee.vim


### PR DESCRIPTION
`javacript` -> `javascript`