### PR TITLE
Update broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # vim-vue
 
 Vim syntax highlighting for [Vue
-components](http://vuejs.org/guide/application.html#Single_File_Components).
+components](https://vuejs.org/v2/guide/single-file-components.html).
 
 This was initially forked from
 [darthmall/vim-vue](https://github.com/darthmall/vim-vue). I already have an


### PR DESCRIPTION
The documentation page for single page components has changed. This updates the link to the new address.