### PR TITLE
Add .vue to 'suffixesadd'

### DIFF
--- a/after/ftplugin/vue.vim
+++ b/after/ftplugin/vue.vim
@@ -1,0 +1,1 @@
+setlocal suffixesadd+=.vue


### PR DESCRIPTION
This allows navigating between `.vue` files using `gf`.

I did it in `after/ftplugin` instead of `ftplugin` because that's the way [vim-javascript](https://github.com/pangloss/vim-javascript/blob/master/after/ftplugin/javascript.vim) and [vim-jsx](https://github.com/mxw/vim-jsx/blob/master/after/ftplugin/jsx.vim) do it, but I'm not sure about the reason.