### PR TITLE
Add compatibility with vim-closetag

### DIFF
--- a/after/ftplugin/vue.vim
+++ b/after/ftplugin/vue.vim
@@ -1,1 +1,10 @@
 setlocal suffixesadd+=.vue
+
+" Add compatibility with vim-closetag
+if exists('g:closetag_filenames')
+  if empty(g:closetag_filenames)
+    let g:closetag_filenames = '*.vue'
+  else
+    let g:closetag_filenames .= ',*.vue'
+  endif
+endif


### PR DESCRIPTION
This makes [vim-closetag](https://github.com/alvan/vim-closetag) work in Vue files.

I'm not sure if it should be vim-vue responsability to do this, so I'll understand if this is not merged. But I think it's a nice (and short) addition.