### PR TITLE
Fixed instructions for vim8, now loads the plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ git clone https://github.com/posva/vim-vue.git
 ### Install without a plugin manager (Vim 8)
 
 ```bash
-git clone https://github.com/posva/vim-vue.git ~/.vim/pack/plugins/start
+git clone https://github.com/posva/vim-vue.git ~/.vim/pack/plugins/start/vim-vue
 ```
 
 ### Integration with [Syntastic](https://github.com/scrooloose/syntastic) or [ALE](https://github.com/w0rp/ale)


### PR DESCRIPTION
My vim8 was not loading the plugin with the native plugin manager. It has to be checked into a subdirectory of start and not directly into start.
This fixes my issues.