### PR TITLE
v- @ : directives support

### DIFF
--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -53,5 +53,6 @@ call s:register_language('less', 'style')
 syn region  vueSurroundingTag   contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent
 syn keyword htmlSpecialTagName  contained template
 syn keyword htmlArg             contained scoped ts
+syn match   htmlArg "[@v:][-:.0-9_a-z]*\>" contained
 
 let b:current_syntax = "vue"


### PR DESCRIPTION
This fixes the highlighting for "v-" and also the shorthand directives "@" ":" for v-bind and v-on. 

https://vuejs.org/v2/guide/syntax.html#Directives
https://vuejs.org/v2/guide/syntax.html#v-bind-Shorthand
https://vuejs.org/v2/guide/syntax.html#v-on-Shorthand