### PR TITLE
fixed incorrect scss highlighting; simplified the syntax file

### DIFF
--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -42,15 +42,15 @@ endfunction
 
 if !exists("g:vue_disable_pre_processors") || !g:vue_disable_pre_processors
   call s:register_language('pug', 'template', s:attr('lang', '\%(pug\|jade\)'))
-  call s:register_language('slm', 'template', s:attr('lang', '\%(slm\)'))
-  call s:register_language('handlebars', 'template', s:attr('lang', '\%(handlebars\)'))
-  call s:register_language('haml', 'template', s:attr('lang', '\%(haml\)'))
+  call s:register_language('slm', 'template')
+  call s:register_language('handlebars', 'template')
+  call s:register_language('haml', 'template')
   call s:register_language('typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)')
-  call s:register_language('coffee', 'script', s:attr('lang', '\%(coffee\)'))
-  call s:register_language('stylus', 'style', s:attr('lang', '\%(stylus\)'))
-  call s:register_language('less', 'style', s:attr('lang', '\%(less\)'))
+  call s:register_language('coffee', 'script')
+  call s:register_language('stylus', 'style')
+  call s:register_language('sass', 'style')
   call s:register_language('scss', 'style', s:attr('lang', '\%(scss\)'))
-  call s:register_language('sass', 'style', s:attr('lang', '\%(scss\)'))
+  call s:register_language('less', 'style')
 endif
 
 syn region  vueSurroundingTag   contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent

--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -42,15 +42,15 @@ endfunction
 
 if !exists("g:vue_disable_pre_processors") || !g:vue_disable_pre_processors
   call s:register_language('pug', 'template', s:attr('lang', '\%(pug\|jade\)'))
-  call s:register_language('slm', 'template')
-  call s:register_language('handlebars', 'template')
-  call s:register_language('haml', 'template')
-  call s:register_language('typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)')
-  call s:register_language('coffee', 'script')
-  call s:register_language('stylus', 'style')
-  call s:register_language('sass', 'style')
-  call s:register_language('scss', 'style')
-  call s:register_language('less', 'style')
+  call s:register_language('slm', 'template', s:attr('lang', '\%(slm\)'))
+  call s:register_language('handlebars', 'template', s:attr('lang', '\%(handlebars\)'))
+  call s:register_language('haml', 'template', s:attr('lang', '\%(haml\)'))
+  call s:register_language('typescript', 'script', s:attr('lang', '\%(ts\|typescript\)'))
+  call s:register_language('coffee', 'script', s:attr('lang', '\%(coffee\)'))
+  call s:register_language('stylus', 'style', s:attr('lang', '\%(stylus\)'))
+  call s:register_language('less', 'style', s:attr('lang', '\%(less\)'))
+  call s:register_language('scss', 'style', s:attr('lang', '\%(scss\)'))
+  call s:register_language('sass', 'style', s:attr('lang', '\%(sass\)'))
 endif
 
 syn region  vueSurroundingTag   contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent

--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -45,12 +45,12 @@ if !exists("g:vue_disable_pre_processors") || !g:vue_disable_pre_processors
   call s:register_language('slm', 'template', s:attr('lang', '\%(slm\)'))
   call s:register_language('handlebars', 'template', s:attr('lang', '\%(handlebars\)'))
   call s:register_language('haml', 'template', s:attr('lang', '\%(haml\)'))
-  call s:register_language('typescript', 'script', s:attr('lang', '\%(ts\|typescript\)'))
+  call s:register_language('typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)')
   call s:register_language('coffee', 'script', s:attr('lang', '\%(coffee\)'))
   call s:register_language('stylus', 'style', s:attr('lang', '\%(stylus\)'))
   call s:register_language('less', 'style', s:attr('lang', '\%(less\)'))
   call s:register_language('scss', 'style', s:attr('lang', '\%(scss\)'))
-  call s:register_language('sass', 'style', s:attr('lang', '\%(sass\)'))
+  call s:register_language('sass', 'style', s:attr('lang', '\%(scss\)'))
 endif
 
 syn region  vueSurroundingTag   contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent


### PR DESCRIPTION
As highlighting was incorrect for scss code (it was not using scss hightlighting for scss code, basically), I fixed it and also simplified the syntax file by setting a regex for each language. This way, it's easier to define a syntax highlighting for each language when adding a new one.

PS: had some trouble passing tests, but I finally did. First time sending a PR; please be nice.