### PR TITLE
Add caw.vim section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,8 +96,6 @@ whole buffer as html/javascript/css instead of only the part inside the tags.
 
 ### How to use commenting functionality with multiple languages in Vue files?
 
-Not out-of-the-box. Luckily, there are solutions in the form of commenting plugins.
-
 #### caw.vim
 
 caw.vim features built-in support for file context through [context_filetype.vim](https://github.com/Shougo/context_filetype.vim). Just install both plugins and context-aware commenting will work in most files. The fenced code is detected by predefined regular expressions.

--- a/readme.md
+++ b/readme.md
@@ -94,11 +94,15 @@ autocmd BufRead,BufNewFile *.vue setlocal filetype=vue.html.javascript.css
 :warning: This may cause problems, because some plugins will then treat the
 whole buffer as html/javascript/css instead of only the part inside the tags.
 
-### How can I use caw.vim in Vue files?
+### How to use commenting functionality with multiple languages in Vue files?
 
-caw.vim already has support built in for file context through [context_filetype.vim](https://github.com/Shougo/context_filetype.vim). Just install both plugins and context-aware commenting will work in most files. The fenced code is detected by predefined regular expressions.
+Not out-of-the-box. Luckily, there are solutions in the form of commenting plugins.
 
-### How can I use NERDCommenter in Vue files?
+#### caw.vim
+
+caw.vim features built-in support for file context through [context_filetype.vim](https://github.com/Shougo/context_filetype.vim). Just install both plugins and context-aware commenting will work in most files. The fenced code is detected by predefined regular expressions.
+
+#### NERDCommenter
 
 <details>
 <summary>

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,10 @@ autocmd BufRead,BufNewFile *.vue setlocal filetype=vue.html.javascript.css
 :warning: This may cause problems, because some plugins will then treat the
 whole buffer as html/javascript/css instead of only the part inside the tags.
 
+### How can I use caw.vim in Vue files?
+
+caw.vim already has support built in for file context through [context_filetype.vim](https://github.com/Shougo/context_filetype.vim). Just install both plugins and context-aware commenting will work in most files. The fenced code is detected by predefined regular expressions.
+
 ### How can I use NERDCommenter in Vue files?
 
 <details>


### PR DESCRIPTION
caw.vim along with context_filetype.vim provides a less error-prone way to reliably comment inside of code blocks. NERDCommenter broke for me several times before I searched for a new solution. This one has proven rock solid so far.