### PR TITLE
Explicitly load javascript/eslint.vim

### DIFF
--- a/syntax_checkers/vue/eslint.vim
+++ b/syntax_checkers/vue/eslint.vim
@@ -6,6 +6,8 @@ endif
 
 let g:loaded_syntastic_vue_eslint_checker = 1
 
+runtime! syntax_checkers/javascript/eslint.vim
+
 call g:SyntasticRegistry.CreateAndRegisterChecker({
       \   'filetype': 'vue',
       \   'name': 'eslint',


### PR DESCRIPTION
In some environments it seems it doesn't load automatically.

Fixes #103