### PR TITLE
Use buffer variables for ALE, and load Vue linters

### DIFF
--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -3,7 +3,7 @@
 " Maintainer: Eduardo San Martin Morote
 " Author: Adriaan Zonnenberg
 
-if exists("b:did_ftplugin")
+if exists('b:did_ftplugin')
   finish
 endif
 
@@ -18,9 +18,7 @@ if !exists('g:no_plugin_maps') && !exists('g:no_vue_maps')
   nnoremap <silent> <buffer> ][ :call search('^</\(template\<Bar>script\<Bar>style\)', 'W')<CR>
 endif
 
-if exists('g:loaded_ale')
-  let g:ale_linters = get(g:, 'ale_linters', {})
-  let g:ale_linters.vue = get(g:ale_linters, 'vue', ['eslint'])
-  let g:ale_linter_aliases = get(g:, 'ale_linter_aliases', {})
-  let g:ale_linter_aliases.vue = get(g:ale_linter_aliases, 'vue', 'javascript')
-endif
+" Run only ESLint for Vue files by default.
+" linters specifically for Vue can still be loaded.
+let b:ale_linter_aliases = ['vue', 'javascript']
+let b:ale_linters = ['eslint']


### PR DESCRIPTION
Someone wants to add `vls` support [over here](https://github.com/w0rp/ale/pull/1699), and for that `'vue'` will need to be included in the aliases for `vue` files. I switched the variables to buffer-local variables, so the ftplugin file doesn't mess with global variables.

I removed the `exists` check because the buffer variables are harmless, and ALE could be loaded after the file is loaded.