### PR TITLE
ale: enable stylelint for vue files

### DIFF
--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -18,7 +18,7 @@ if !exists('g:no_plugin_maps') && !exists('g:no_vue_maps')
   nnoremap <silent> <buffer> ][ :call search('^</\(template\<Bar>script\<Bar>style\)', 'W')<CR>
 endif
 
-" Run only ESLint for Vue files by default.
+" Run only ESLint and stylelint for Vue files by default.
 " linters specifically for Vue can still be loaded.
-let b:ale_linter_aliases = ['vue', 'javascript']
-let b:ale_linters = ['eslint']
+let b:ale_linter_aliases = ['vue', 'javascript', 'css']
+let b:ale_linters = ['eslint', 'stylelint']


### PR DESCRIPTION
Since stylelint has out of the box support for vue-files, it can be safely enabled. It seems there's no other way to enable it easily otherwise, I tried and failed (see https://github.com/w0rp/ale/issues/1712 for reference).