### PR TITLE
Default to the vimrc linter setting if availble

### DIFF
--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -21,4 +21,4 @@ endif
 " Run only ESLint for Vue files by default.
 " linters specifically for Vue can still be loaded.
 let b:ale_linter_aliases = ['vue', 'javascript']
-let b:ale_linters = ['eslint']
+let b:ale_linters = get(get(g:, 'ale_linters', {}), 'vue', ['eslint', 'vls'])

--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -20,5 +20,5 @@ endif
 
 " Run only ESLint for Vue files by default.
 " linters specifically for Vue can still be loaded.
-let b:ale_linter_aliases = ['vue', 'javascript']
+let b:ale_linter_aliases = get(get(g:, 'ale_linter_aliases', {}), 'vue', ['vue', 'javascript'])
 let b:ale_linters = get(get(g:, 'ale_linters', {}), 'vue', ['eslint', 'vls'])


### PR DESCRIPTION
This patch will use the linter setting from vimrc if it's set up by someone in the buffer-local setting. I also enabled the `vls` linter by default.