### PR TITLE
Don't set options for ALE

### DIFF
--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -17,8 +17,3 @@ if !exists('g:no_plugin_maps') && !exists('g:no_vue_maps')
   nnoremap <silent> <buffer> [] :call search('^</\(template\<Bar>script\<Bar>style\)', 'bW')<CR>
   nnoremap <silent> <buffer> ][ :call search('^</\(template\<Bar>script\<Bar>style\)', 'W')<CR>
 endif
-
-" Run only ESLint for Vue files by default.
-" linters specifically for Vue can still be loaded.
-let b:ale_linter_aliases = get(get(g:, 'ale_linter_aliases', {}), 'vue', ['vue', 'javascript'])
-let b:ale_linters = get(get(g:, 'ale_linters', {}), 'vue', ['eslint', 'vls'])


### PR DESCRIPTION
Setting options for ALE in this file can sometimes overwrite settings that users set, say if they set global settings for ALE after ftplugin files are loaded. The Vue files should not be checked with ESLint by default, and ESLint checking should be enabled manually after installing the Vue ESLint plugin. I keep getting issues reported with these settings in ALE, because they are set here.