### PR TITLE
Allow granular control over loading pre-processor syntax files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,5 +128,14 @@ endfunction
 </details>
 
 ### _Vim slows down when using this plugin_ How can I fix that?
+When checking for pre-processor languages, multiple syntax highlighting checks are done, which can slow down vim. You can trim down which pre-processors to use by setting `g:vue_pre_processors` to a whitelist of languages to support:
 
-Add `let g:vue_disable_pre_processors=1` in your .vimrc to disable checking for prepocessors. When checking for preprocessor languages, multiple syntax highlighting checks are done, which can slow down vim. This variable prevents vim-vue from supporting **every** pre-processor language highlighting.
+```vim
+let g:vue_pre_processors = ['pug', 'scss']
+```
+
+Or alternatively, disable pre-processor languages altogether:
+
+```vim
+let g:vue_disable_pre_processors = 1
+```

--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -42,30 +42,33 @@ function! s:register_language(language, tag, ...)
   endif
 endfunction
 
-let s:language_config = {
-      \ 'less':       ['less', 'style'],
-      \ 'pug':        ['pug', 'template', s:attr('lang', '\%(pug\|jade\)')],
-      \ 'slm':        ['slm', 'template'],
-      \ 'handlebars': ['handlebars', 'template'],
-      \ 'haml':       ['haml', 'template'],
-      \ 'typescript': ['typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)'],
-      \ 'coffee':     ['coffee', 'script'],
-      \ 'stylus':     ['stylus', 'style'],
-      \ 'sass':       ['sass', 'style'],
-      \ 'scss':       ['scss', 'style'],
-      \ }
-
+let s:language_config = [
+      \ {'lang': 'less',       'args': ['less', 'style']},
+      \ {'lang': 'pug',        'args': ['pug', 'template', s:attr('lang', '\%(pug\|jade\)')]},
+      \ {'lang': 'slm',        'args': ['slm', 'template']},
+      \ {'lang': 'handlebars', 'args': ['handlebars', 'template']},
+      \ {'lang': 'haml',       'args': ['haml', 'template']},
+      \ {'lang': 'typescript', 'args': ['typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)']},
+      \ {'lang': 'coffee',     'args': ['coffee', 'script']},
+      \ {'lang': 'stylus',     'args': ['stylus', 'style']},
+      \ {'lang': 'sass',       'args': ['sass', 'style']},
+      \ {'lang': 'scss',       'args': ['scss', 'style']},
+      \ ]
+let s:language_dict = {}
+for item in s:language_config
+  let s:language_dict[item.lang] = item.args
+endfor
 
 if !exists("g:vue_disable_pre_processors") || !g:vue_disable_pre_processors
   if exists("g:vue_pre_processors")
     let pre_processors = g:vue_pre_processors
   else
-    let pre_processors = keys(s:language_config)
+    let pre_processors = map(copy(s:language_config), {k, v -> v.lang})
   endif
 
   for language in pre_processors
-    if has_key(s:language_config, language)
-      call call("s:register_language", get(s:language_config, language))
+    if has_key(s:language_dict, language)
+      call call("s:register_language", get(s:language_dict, language))
     endif
   endfor
 endif

--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -42,17 +42,32 @@ function! s:register_language(language, tag, ...)
   endif
 endfunction
 
+let s:language_config = {
+      \ 'less':       ['less', 'style'],
+      \ 'pug':        ['pug', 'template', s:attr('lang', '\%(pug\|jade\)')],
+      \ 'slm':        ['slm', 'template'],
+      \ 'handlebars': ['handlebars', 'template'],
+      \ 'haml':       ['haml', 'template'],
+      \ 'typescript': ['typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)'],
+      \ 'coffee':     ['coffee', 'script'],
+      \ 'stylus':     ['stylus', 'style'],
+      \ 'sass':       ['sass', 'style'],
+      \ 'scss':       ['scss', 'style'],
+      \ }
+
+
 if !exists("g:vue_disable_pre_processors") || !g:vue_disable_pre_processors
-  call s:register_language('less', 'style')
-  call s:register_language('pug', 'template', s:attr('lang', '\%(pug\|jade\)'))
-  call s:register_language('slm', 'template')
-  call s:register_language('handlebars', 'template')
-  call s:register_language('haml', 'template')
-  call s:register_language('typescript', 'script', '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)')
-  call s:register_language('coffee', 'script')
-  call s:register_language('stylus', 'style')
-  call s:register_language('sass', 'style')
-  call s:register_language('scss', 'style')
+  if exists("g:vue_pre_processors")
+    let pre_processors = g:vue_pre_processors
+  else
+    let pre_processors = keys(s:language_config)
+  endif
+
+  for language in pre_processors
+    if has_key(s:language_config, language)
+      call call("s:register_language", get(s:language_config, language))
+    endif
+  endfor
 endif
 
 syn region  vueSurroundingTag   contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent


### PR DESCRIPTION
In addition to `g:vue_disable_pre_processors`, which is an "all or nothing" approach to loading pre-processor syntax files, a `g:vue_pre_processors` option is exposed as well. This is a List of names of pre-processor syntaxes to load, to allow the user to enjoy syntax highlighting for one or two pre-processor languages without incurring the performance penalty of loading all of them at the same time.

Notable reasons not to merge this:

- PR #109 does something similar with indent configuration, and acknowledges its possible extension to syntax configuration in [this comment](https://github.com/posva/vim-vue/pull/109#issuecomment-400002006). Perhaps a more unified solution can be done instead of merging this PR directly.
- There is already some work towards loading languages lazily, as in #128. If this work is completed and the language detection works well enough, there wouldn't be a need for `g:vue_pre_processors` altogether.

In the meantime, however, as none of the above solutions are fleshed out as of yet (particularly in the context of syntax), this change could be a way to mitigate the issue.