### PR TITLE
Use mustache syntax for handlebars templates

### DIFF
--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -43,7 +43,7 @@ let s:languages = [
       \ {'name': 'less',       'tag': 'style'},
       \ {'name': 'pug',        'tag': 'template', 'attr_pattern': s:attr('lang', '\%(pug\|jade\)')},
       \ {'name': 'slm',        'tag': 'template'},
-      \ {'name': 'handlebars', 'tag': 'template'},
+      \ {'name': 'mustache',   'tag': 'template', 'attr_pattern': s:attr('lang', '\%(mustache\|handlebars\)')},
       \ {'name': 'haml',       'tag': 'template'},
       \ {'name': 'typescript', 'tag': 'script', 'attr_pattern': '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)'},
       \ {'name': 'coffee',     'tag': 'script'},


### PR DESCRIPTION
I don't know how many people use handlebars templates in vue files, but I think that the standard way of highlighting handlebars syntax is with this plugin:

https://github.com/mustache/vim-mustache-handlebars

Now, the aforementioned plugin sets the syntax to mustache, so in order to render a template defined with
```html
<template lang="handlebars">
```

we need to set its syntax to mustache, instead of handlebars.

The way I did that, was copying what was done for pug templates, and adapting it.

This patch somewhat works, but there is a problem rendering handlebars comments:

When using

```
{{!--
```

on a standalone handlebars file, it is correctly rendered as a comment, but inside a vue file, it is rendered as an error instead, and I can't figure out why.