### PR TITLE
Fix indentation for TypeScript

### DIFF
--- a/indent/vue.vim
+++ b/indent/vue.vim
@@ -20,6 +20,7 @@ let s:languages = [
       \   { 'name': 'stylus', 'pairs': ['<style lang="stylus"', '</style>'] },
       \   { 'name': 'css', 'pairs': ['<style', '</style>'] },
       \   { 'name': 'coffee', 'pairs': ['<script lang="coffee"', '</script>'] },
+      \   { 'name': 'typescript', 'pairs': ['<script lang="ts"', '</script>'] },
       \   { 'name': 'javascript', 'pairs': ['<script', '</script>'] },
       \ ]
 


### PR DESCRIPTION
While the syntax highlighting had support for this, indentation did not. This left it indenting things way too far.