### PR TITLE
Add reference to vim-vue-plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,9 @@ This was initially forked from
 implementation for this but found his code much cleaner. That's why I created a
 new version instead of a PR.
 
+This project is not the most active Vue plugin for Vim.
+One alternative that is updated more frequently is [leafOfTree/vim-vue-plugin](https://github.com/leafOfTree/vim-vue-plugin).
+
 ## Installation
 
 ### Install with [Vundle](https://github.com/VundleVim/Vundle.vim)

--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,7 @@ implementation for this but found his code much cleaner. That's why I created a
 new version instead of a PR.
 
 > [!WARNING]
-> This project is currently not actively maintained. Some alternatives that receive more frequent updates:
->
-> - [leafOfTree/vim-vue-plugin](https://github.com/leafOfTree/vim-vue-plugin)
-> - [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
-> - [vuejs/language-tools](https://github.com/vuejs/language-tools?tab=readme-ov-file#community-integration)
+> This project is currently not actively maintained. We recommend to check the official [vuejs/language-tools](https://github.com/vuejs/language-tools?tab=readme-ov-file#community-integration) instead.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,12 @@ This was initially forked from
 implementation for this but found his code much cleaner. That's why I created a
 new version instead of a PR.
 
-This project is not the most active Vue plugin for Vim.
-One alternative that is updated more frequently is [leafOfTree/vim-vue-plugin](https://github.com/leafOfTree/vim-vue-plugin).
+> [!WARNING]
+> This project is currently not actively maintained. Some alternatives that receive more frequent updates:
+>
+> - [leafOfTree/vim-vue-plugin](https://github.com/leafOfTree/vim-vue-plugin)
+> - [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+> - [vuejs/language-tools](https://github.com/vuejs/language-tools?tab=readme-ov-file#community-integration)
 
 ## Installation
 


### PR DESCRIPTION
Just an idea - may want to reference [`leafOfTree/vim-vue-plugin`](https://github.com/leafOfTree/vim-vue-plugin) as an alternative.

Thanks for your work on this plugin!